### PR TITLE
fixed tests and split components out into separate files

### DIFF
--- a/__tests__/test-example-work.js
+++ b/__tests__/test-example-work.js
@@ -9,7 +9,6 @@ import Adapter from 'enzyme-adapter-react-16.3';
 Enzyme.configure({ adapter: new Adapter() });
 
 const myWork = [
-
     {
       'title': "Zoom",
       'image': {

--- a/js/example-work-bubble.js
+++ b/js/example-work-bubble.js
@@ -3,19 +3,24 @@ import React from 'react';
 class ExampleWorkBubble extends React.Component {
   render() {
     let example = this.props.example; // to shorten the code below
-    return(<div className="section__exampleWrapper">
-      <div className="section__example">
-        <img alt={ example.image.desc } // "example screenshot of a project involving code"
-             className="section__exampleImage"
-             src={ example.image.src } />
-        <dl className="color--cloud">
-          <dt className="section__exampleTitle section__text--centered">
-            { example.title }
-          </dt>
-          <dd></dd>
-        </dl>
-      </div>
-    </div>)
+    return (
+        <div className="section__exampleWrapper">
+          <div className="section__example">
+            // "example screenshot of a project involving code"
+            <img
+                className="section__exampleImage"
+                alt={ example.image.desc }
+                src={ example.image.src }
+            />
+            <dl className="color--cloud">
+              <dt className="section__exampleTitle section__text--centered">
+                { example.title }
+              </dt>
+              <dd></dd>
+            </dl>
+          </div>
+        </div>
+    )
   }
 }
 

--- a/js/example-work.js
+++ b/js/example-work.js
@@ -6,11 +6,12 @@ class ExampleWork extends React.Component {
     return (
       <section className="section section--alignCentered section--description">
 
-        { this.props.work.map ( (example, idx) => {
-          return (
-            <ExampleWorkBubble example={example} key={idx} />
-            )
-          })
+        {
+            this.props.work.map ((example, idx) => {
+              return (
+                    <ExampleWorkBubble example={example} key={idx} />
+                )
+            })
         }
 
 


### PR DESCRIPTION
@john-neil your problems involved:
- you weren't exporting ExampleWorkBubble properly. you were only doing `export default ExampleWork` in `example-work.js`. So i split out ExampleWorkBubble into a separate file: `example-work-bubble.js` and did `export default ExampleWorkBubble` in that. Then i imported that component into `example-work.js`and your test
- you were accessing the wrong thing with `image.props('src')` -- you needed to do `image.props().src` because props() is a function that returns the component's props as an object. passing 'src' as an argument wasn't doing what you thought - the 'src' argument was being ignored and then the test was testing against the entire props object instead of the src prop specifically.